### PR TITLE
Suggestion to get wNow from production[0]

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ AirQualityAccessory.prototype.getCo2Level = function(callback) {
     if (!err && response.statusCode == 200) {
     var json = JSON.parse(body);
     if (this.connection == "local") {
-    	let power = Math.round(parseFloat(json.production[1].wNow));
+    	let power = Math.round(parseFloat(json.production[0].wNow));
     	this.co2CurrentLevel = (power >= 0) ? power : 0;
     }
     else {


### PR DESCRIPTION
Suggestion to get wNow from `production[1]` to `production[0]`. Currently the plugin always reports the current production as 0 Watts, even if there is sun and powerproduction (checked on envoy.local)

For me the envoy production.json looks like this (new installation June 2020, unmetered enphase envoy-s with 9 Enphase Microinverters and 9 panels, Firmware: **R4.10.35**):

```
 {
   "production":[
      {
         "type":"inverters",
         "activeCount":9,
         "readingTime":1592207066,
         "wNow":434,
         "whLifetime":63554
      },
      {
         "type":"eim",
         "activeCount":0,
         "measurementType":"production",
         "readingTime":1592207068,
         "wNow":0.0,
         "whLifetime":0.0,
         "varhLeadLifetime":0.0,
         "varhLagLifetime":0.0,
         "vahLifetime":0.0,
         "rmsCurrent":-0.0,
         "rmsVoltage":230.466,
         "reactPwr":0.0,
         "apprntPwr":-0.0,
         "pwrFactor":0.0,
         "whToday":0.0,
         "whLastSevenDays":0.0,
         "vahToday":0.0,
         "varhLeadToday":0.0,
         "varhLagToday":0.0
      }
   ],
   "consumption":[
      {
         "type":"eim",
         "activeCount":0,
         "measurementType":"total-consumption",
         "readingTime":1592207068,
         "wNow":-4.552,
         "whLifetime":0.0,
         "varhLeadLifetime":0.0,
         "varhLagLifetime":0.0,
         "vahLifetime":0.0,
         "rmsCurrent":-0.46,
         "rmsVoltage":238.219,
         "reactPwr":-0.0,
         "apprntPwr":-109.566,
         "pwrFactor":-1.0,
         "whToday":0.0,
         "whLastSevenDays":0.0,
         "vahToday":0.0,
         "varhLeadToday":0.0,
         "varhLagToday":0.0
      },
      {
         "type":"eim",
         "activeCount":0,
         "measurementType":"net-consumption",
         "readingTime":1592207068,
         "wNow":-4.552,
         "whLifetime":0.0,
         "varhLeadLifetime":0.0,
         "varhLagLifetime":0.0,
         "vahLifetime":0.0,
         "rmsCurrent":0.46,
         "rmsVoltage":245.971,
         "reactPwr":-0.0,
         "apprntPwr":59.334,
         "pwrFactor":-0.12,
         "whToday":0,
         "whLastSevenDays":0,
         "vahToday":0,
         "varhLeadToday":0,
         "varhLagToday":0
      }
   ],
   "storage":[
      {
         "type":"acb",
         "activeCount":0,
         "readingTime":0,
         "wNow":0,
         "whNow":0,
         "state":"idle"
      }
   ]
}
```